### PR TITLE
Add contribution guides and navigation

### DIFF
--- a/docs/contribute-analytics-library.md
+++ b/docs/contribute-analytics-library.md
@@ -1,0 +1,35 @@
+# Contribute to the Analytics Library
+
+**Goal:** an **analysis pattern** that accepts generic data types and demonstrates the **inference** the method provides—**not** tied to a specific dataset.
+
+## Required sections
+1. **When to use** — questions the method answers; assumptions.
+2. **Inputs & assumptions** — generic data shapes/types; preconditions.
+3. **Step‑by‑step** (R/Python) — minimal, runnable example.
+4. **Result plot + interpretation** — show output **and explain how to read it**.
+5. **Settings & sensitivity** — how parameters change outcomes; defaults to start with.
+6. **Pitfalls & limitations** — where it fails; what to avoid; checks to run.
+
+## Author checklist
+- [ ] Works on **generic** data types (not fixed to one dataset)
+- [ ] Produces a result plot **with interpretation guidance**
+- [ ] Explains parameters/settings and their effects
+- [ ] Notes pitfalls/limitations and when to avoid the method
+- [ ] License and links set; assets < 2 MB; alt text present
+
+## Style guide (authoritative)
+Follow the Analytics Library style rules:  
+https://github.com/CU-ESIIL/analytics-library/blob/main/docs/style-guide.md
+
+## Tiny example (placeholder)
+```python
+# Python
+# yhat, diag = fit_and_predict(x, params)
+# plt.plot(t, y, label="obs"); plt.plot(t, yhat, label="fit"); plt.legend()
+```
+
+```r
+# R
+# fit <- method(x, params)
+# plot_result(fit)  # include a short paragraph interpreting the figure
+```

--- a/docs/contribute-data-library.md
+++ b/docs/contribute-data-library.md
@@ -1,0 +1,35 @@
+# Contribute to the Data Library
+
+**Goal:** cut‑and‑paste R/Python that connects to a dataset, plus one **raw‑data plot** to prove it worked, and **scientific context** so users apply it responsibly.
+
+## Required sections
+1. **Overview** — what the dataset is; coverage; variables; resolution.
+2. **Access / Streaming** — R and/or Python snippet that downloads/streams the data.
+3. **Quick raw‑data plot** — immediate plot of what you just pulled.
+4. **Scientific context** — how people use this scientifically; caveats.
+5. **Citation** — how to cite dataset and creators.
+6. **Troubleshooting** — common errors, auth, CRS, etc.
+
+## Author checklist
+- [ ] Streams/downloads from an authoritative source
+- [ ] One quick plot of the **raw** data to prove it works
+- [ ] Scientific context (what, where, why, how used)
+- [ ] Full citation & license
+- [ ] Links live; assets < 2 MB; alt text present
+
+## Style sheet (authoritative)
+Follow the Data Library style rules:  
+https://github.com/CU-ESIIL/data-library/blob/main/STYLE_SHEET.md
+
+## Tiny example (placeholder)
+```python
+# Python
+# df = fetch_dataset(...)
+# df.plot(); plt.show()  # raw diagnostic plot
+```
+
+```r
+# R
+# df <- fetch_dataset(...)
+# plot(df)               # raw diagnostic plot
+```

--- a/docs/contribute-oasis.md
+++ b/docs/contribute-oasis.md
@@ -1,0 +1,23 @@
+# Contribute to OASIS (Org‑level docs)
+
+Use this when your contribution is **cross‑cutting**: Quickstarts, Containers, Resources, or site templates that help people navigate or bootstrap work.
+
+## Scope examples
+- “Getting Started” docs, contributor onboarding, CI templates
+- Container recipes or reproducible environment templates
+- Org‑wide navigation or tagging improvements
+
+## Author checklist
+- [ ] Clear purpose and scope
+- [ ] Minimal reproducible example if code/config is included
+- [ ] Images < 2 MB with alt text
+- [ ] License chosen (docs: CC‑BY‑4.0; code: OSI approved)
+- [ ] Links verified
+
+## Submission path
+1. Open an **Issue** in this repo with a one‑paragraph abstract and links.
+2. When ready, open a **PR** adding/adjusting pages.
+3. CI must pass (build, links, lint). Reviewers will respond within **5 business days**.
+
+!!! note "Benefits & expectations"
+    Your work becomes the entry point for others. Keep pages succinct and evergreen; prefer linking to detailed guides in sub‑repos.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,29 @@
+# Contribute to OASIS
+
+OASIS is our GitHub organization hub—a **templating** and **navigation** system for CI‑friendly research. We welcome contributions that help people **find data**, **apply sound analyses**, and **build reproducible workflows**.
+
+## Why contribute?
+- **Impact** — your methods and data access patterns help the community move faster.
+- **Reproducibility** — shared, reviewable pages with copy‑paste code and clear context.
+- **Visibility** — your work is discoverable across the OASIS ecosystem.
+
+## Where should my contribution go?
+- **OASIS docs** → org‑level guidance, templates, and cross‑cutting resources.  
+  → [Contribute to OASIS](contribute-oasis.md)
+- **Data Library** → copy‑paste R/Python to access a dataset + a quick raw‑data plot + scientific context.  
+  → [Contribute to the Data Library](contribute-data-library.md)
+- **Analytics Library** → analysis patterns that work on generic data types, with interpretation guidance.  
+  → [Contribute to the Analytics Library](contribute-analytics-library.md)
+
+!!! tip "Before you begin"
+    If you’re on JupyterHub, set up SSH and use the Git widget. Link your local docs here, e.g. `/resources/ssh.md`, `/resources/git-widget.md`.
+
+---
+
+## How submissions work (quick view)
+1. Open an **Issue** describing your idea (target: OASIS/Data/Analytics).
+2. Use the **template** that matches your target.
+3. Open a **Pull Request**; CI must pass (build, links, lint).
+4. Editors review within **5 business days**.
+
+**Ready?** Start with: [Contribute to OASIS](contribute-oasis.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,10 @@ copyright: 'Copyright &copy; 2023 University of Colorado Boulder'
 # Page tree
 nav:
   - Home: index.md
+  - Contributing:
+      - Contribute to OASIS: contribute-oasis.md
+      - Contribute to the Data Library: contribute-data-library.md
+      - Contribute to the Analytics Library: contribute-analytics-library.md
   # TODO: Add your nav sections / sub-sections and path to markdown page Ex:
   # - Remote Sensing:
   #     - How to Cloud Correct Sentinel-2 Images: remote_sensing/sentinel_2_cloud_correction/sentinel_2_cloud_correction.md


### PR DESCRIPTION
## Summary
- expand navigation with dedicated Contributing section
- add landing page and contribution guides for OASIS, Data Library, and Analytics Library

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c4852871248325b68679b727d261e6