### PR TITLE
Refine contribution docs and add CTAs

### DIFF
--- a/docs/assets/cta.css
+++ b/docs/assets/cta.css
@@ -1,0 +1,29 @@
+.cta-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin: 1rem 0 1.25rem;
+}
+
+a.cta {
+  display: inline-block;
+  font-size: clamp(1.05rem, 1.8vw, 1.25rem); /* bigger than default */
+  font-weight: 700;
+  padding: 0.85rem 1.25rem;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+  transition: transform .08s ease-out, box-shadow .12s ease-out;
+  box-shadow: 0 1px 0 rgba(0,0,0,.12);
+}
+
+a.cta.secondary {
+  background: var(--md-accent-fg-color);
+  color: var(--md-accent-bg-color);
+}
+
+a.cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(0,0,0,.12);
+}

--- a/docs/contribute-analytics-library.md
+++ b/docs/contribute-analytics-library.md
@@ -2,6 +2,11 @@
 
 **Goal:** an **analysis pattern** that accepts generic data types and demonstrates the **inference** the method provides—**not** tied to a specific dataset.
 
+> **Keep it generic:** Avoid tying the method to a single named dataset. Accept **generic data types** and show how to adapt.
+
+!!! tip "Don’t skip interpretation"
+    Every result plot should include 2–3 sentences explaining **how to read the output** and **what inference** the method supports.
+
 ## Required sections
 1. **When to use** — questions the method answers; assumptions.
 2. **Inputs & assumptions** — generic data shapes/types; preconditions.

--- a/docs/contribute-data-library.md
+++ b/docs/contribute-data-library.md
@@ -10,6 +10,8 @@
 5. **Citation** — how to cite dataset and creators.
 6. **Troubleshooting** — common errors, auth, CRS, etc.
 
+> **Reminder:** Every Data Library page must include one quick **raw-data plot** immediately after access, to show that the code worked.
+
 ## Author checklist
 - [ ] Streams/downloads from an authoritative source
 - [ ] One quick plot of the **raw** data to prove it works

--- a/docs/contribute-oasis.md
+++ b/docs/contribute-oasis.md
@@ -1,5 +1,8 @@
 # Contribute to OASIS (Org‑level docs)
 
+!!! note "What is OASIS?"
+    OASIS is our GitHub organization hub — a templating and navigation system for CI‑friendly research. It hosts the sites and templates that tie the ecosystem together.
+
 Use this when your contribution is **cross‑cutting**: Quickstarts, Containers, Resources, or site templates that help people navigate or bootstrap work.
 
 ## Scope examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,29 +1,32 @@
-# Contribute to OASIS
+# Contribute
 
-OASIS is our GitHub organization hub—a **templating** and **navigation** system for CI‑friendly research. We welcome contributions that help people **find data**, **apply sound analyses**, and **build reproducible workflows**.
+Welcome! This site explains **how to contribute** new pages, data access examples, and analysis patterns. It’s designed for quick onboarding and consistent, high-quality submissions.
 
 ## Why contribute?
-- **Impact** — your methods and data access patterns help the community move faster.
-- **Reproducibility** — shared, reviewable pages with copy‑paste code and clear context.
-- **Visibility** — your work is discoverable across the OASIS ecosystem.
+- **Impact** — your examples and methods help the community work faster.
+- **Reproducibility** — copy‑paste code with clear context and lightweight review.
+- **Visibility** — your work is published and easily discoverable.
 
 ## Where should my contribution go?
-- **OASIS docs** → org‑level guidance, templates, and cross‑cutting resources.  
+- **Org‑level docs** → cross‑cutting guidance, templates, resources.  
   → [Contribute to OASIS](contribute-oasis.md)
 - **Data Library** → copy‑paste R/Python to access a dataset + a quick raw‑data plot + scientific context.  
   → [Contribute to the Data Library](contribute-data-library.md)
-- **Analytics Library** → analysis patterns that work on generic data types, with interpretation guidance.  
+- **Analytics Library** → analysis patterns for generic data types, with interpretation guidance.  
   → [Contribute to the Analytics Library](contribute-analytics-library.md)
 
+<div class="cta-row">
+  <a class="cta" href="contribute-data-library/">Start with Data Library</a>
+  <a class="cta secondary" href="contribute-analytics-library/">Start with Analytics</a>
+</div>
+
 !!! tip "Before you begin"
-    If you’re on JupyterHub, set up SSH and use the Git widget. Link your local docs here, e.g. `/resources/ssh.md`, `/resources/git-widget.md`.
+    If you’re on JupyterHub, set up SSH and use the Git widget. Link your local guides here.
 
 ---
 
 ## How submissions work (quick view)
-1. Open an **Issue** describing your idea (target: OASIS/Data/Analytics).
+1. Open an **Issue** describing your idea (target: Org / Data / Analytics).
 2. Use the **template** that matches your target.
 3. Open a **Pull Request**; CI must pass (build, links, lint).
 4. Editors review within **5 business days**.
-
-**Ready?** Start with: [Contribute to OASIS](contribute-oasis.md)

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,1 @@
+/* extra styles placeholder */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: 'Your Site Name'
+site_name: How to Contribute
 #site_description: TODO: Uncomment and change to your site description Ex:'Analysis Modules for Environmental Data Science'
 #site_author: TODO: Uncomment and change to your site author(s) Ex: ESIIL CI team (lead = Ty Tuff)
 #site_url: TODO: Uncomment and change to your site url Ex: https://cu-esiil.github.io/analytics-library
@@ -14,7 +14,7 @@ copyright: 'Copyright &copy; 2023 University of Colorado Boulder'
 # Page tree
 nav:
   - Home: index.md
-  - Contributing:
+  - Start contributing:
       - Contribute to OASIS: contribute-oasis.md
       - Contribute to the Data Library: contribute-data-library.md
       - Contribute to the Analytics Library: contribute-analytics-library.md
@@ -33,14 +33,11 @@ theme:
   #favicon: # TODO: Uncomment and add path to your favicon .png Ex: 'assets/favicon.ico'
   # setting features for the navigation tab
   features:
+    - navigation.tabs
     - navigation.sections
     - navigation.instant
-    - navigation.tracking
-    - navigation.indexes
-    - navigation.top
-    - toc.integrate
-    - toc.follow
     - content.code.copy
+    - search.suggest
   # Default values, taken from mkdocs_theme.yml
   language: en
   palette:
@@ -66,6 +63,7 @@ extra:
 
 extra_css:
   - stylesheets/extra.css
+  - assets/cta.css
 
 plugins:
     - search


### PR DESCRIPTION
## Summary
- Refresh home page with general contribution overview and animate-on-hover CTA buttons
- Clarify OASIS, Data Library, and Analytics Library contributor guides
- Update theme settings and navigation; add CTA stylesheet

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68c4878ee3c883259cb43f55232e8eb2