### PR TITLE
fix: render homepage buttons in MkDocs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
 
 markdown_extensions:
   - attr_list
+  - md_in_html
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
## Summary
- enable Markdown inside HTML so home page buttons render properly

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c48ee11a2c8325b0356f397a5d39b7