### PR TITLE
Update homepage CTA layout and styling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,10 @@
 
 <!-- Three big CTAs; no other content -->
 
-<div class="grid cards" markdown>
+Choose the contribution guide that matches the work you are doing. The buttons below point you to the resources for updating OASIS content, adding new datasets, or sharing analysis methods.
 
--   :octicons-repo-16: **Contribute to OASIS**  
-    [Go to OASIS contribution guide](contribute-oasis/ "Org-level docs, templates, navigation"){ .md-button .md-button--primary }
-
--   :octicons-database-16: **Contribute to the Data Library**  
-    [Add a dataset page](contribute-data-library/ "Streaming code + quick plot + context"){ .md-button }
-
--   :octicons-graph-16: **Contribute to the Analytics Library**  
-    [Add an analysis method page](contribute-analytics-library/ "Generic inputs + result plot + interpretation"){ .md-button }
+<div class="cta-buttons" markdown>
+[ :octicons-repo-16: **Contribute to OASIS**](contribute-oasis/ "Org-level docs, templates, navigation"){ .md-button .md-button--primary }
+[ :octicons-database-16: **Contribute to the Data Library**](contribute-data-library/ "Streaming code + quick plot + context"){ .md-button .md-button--primary }
+[ :octicons-graph-16: **Contribute to the Analytics Library**](contribute-analytics-library/ "Generic inputs + result plot + interpretation"){ .md-button .md-button--primary }
 </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,1 +1,14 @@
 /* extra styles placeholder */
+
+.cta-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.cta-buttons .md-button {
+  flex: 1 1 12rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add an overview paragraph above the homepage contribution call-to-action buttons
- restyle the buttons into a single flexible row while applying the primary color scheme to each

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68c85fef4d588325a00a582285473927